### PR TITLE
feat: attribution to open source community

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,25 @@ data/adapted/     Final JSON Resume + PDFs (auto-generated)
 .github/          GitHub Actions workflows (fit, extract, structurize, deploy, pdf)
 ```
 
+## Credits
+
+AgentFolio stands on the shoulders of open source. Thanks to:
+
+**Resume stack**
+- [JSON Resume](https://jsonresume.org/) — the open resume schema that every adaptation conforms to
+- [jsonresume-theme-developer-mono](https://github.com/jrpruit1/jsonresume-theme-developer-mono) — `web/src/components/ResumeTheme.tsx` is adapted from this theme
+- [jsonresume-theme-onepage](https://github.com/findup-dev/jsonresume-theme-onepage) — PDF theme used by the `pdf` workflow
+- [resumed](https://github.com/rbardini/resumed) — CLI that drives PDF export
+
+**Framework**
+- [React](https://react.dev/), [Vite](https://vitejs.dev/), [TypeScript](https://www.typescriptlang.org/), [styled-components](https://styled-components.com/), [react-markdown](https://github.com/remarkjs/react-markdown), [diff](https://github.com/kpdecker/jsdiff)
+- [Vitest](https://vitest.dev/), [Playwright](https://playwright.dev/) — test runners
+- [Puppeteer](https://pptr.dev/) — PDF rendering inside the workflow
+- [Cloudflare Workers](https://workers.cloudflare.com/) — chat proxy runtime
+
+**Agentic engine**
+- [Claude Code](https://claude.com/claude-code) by Anthropic — powers the `/fit`, `/extract-directives`, and `/structurize` skills
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ AgentFolio stands on the shoulders of open source. Thanks to:
 
 **Resume stack**
 - [JSON Resume](https://jsonresume.org/) — the open resume schema that every adaptation conforms to
-- [jsonresume-theme-developer-mono](https://github.com/jrpruit1/jsonresume-theme-developer-mono) — `web/src/components/ResumeTheme.tsx` is adapted from this theme
-- [jsonresume-theme-onepage](https://github.com/findup-dev/jsonresume-theme-onepage) — PDF theme used by the `pdf` workflow
+- [jsonresume-theme-developer-mono](https://www.npmjs.com/package/jsonresume-theme-developer-mono) by Thomas Davis — `web/src/components/ResumeTheme.tsx` is adapted from this theme
+- [jsonresume-theme-onepage](https://github.com/ainsleychong/jsonresume-theme-onepage) by Ainsley Chong — PDF theme used by the `pdf` workflow
 - [resumed](https://github.com/rbardini/resumed) — CLI that drives PDF export
 
 **Framework**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { ResumeTheme } from './components/ResumeTheme';
 import { DownloadPdf } from './components/DownloadPdf';
 import { Dashboard } from './components/Dashboard';
 import { ChatWidget } from './components/ChatWidget';
+import { Footer } from './components/Footer';
 import { parseFitSummary } from './utils/parseFitSummary';
 
 function isDashboard(): boolean {
@@ -65,6 +66,7 @@ function ResumePage() {
     <>
       <DownloadPdf slug={slug} />
       <ResumeTheme resume={adapted as unknown as Record<string, unknown>} />
+      <Footer />
       {target && <ChatWidget key={activeSlug} slug={activeSlug} target={target} />}
     </>
   );

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -1,0 +1,44 @@
+import styled from 'styled-components';
+
+const FooterWrapper = styled.footer`
+  max-width: 800px;
+  margin: 40px auto 24px;
+  padding: 16px 40px 0;
+  border-top: 1px solid #e5e7eb;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 12px;
+  color: #6b7280;
+  text-align: center;
+  line-height: 1.6;
+
+  a {
+    color: #6b7280;
+    text-decoration: underline;
+    text-decoration-color: #d1d5db;
+  }
+
+  a:hover {
+    color: #2563eb;
+    text-decoration-color: #2563eb;
+  }
+
+  @media print {
+    display: none;
+  }
+`;
+
+export function Footer() {
+  return (
+    <FooterWrapper>
+      Built with{' '}
+      <a href="https://github.com/verkyyi/agentfolio" target="_blank" rel="noopener noreferrer">
+        AgentFolio
+      </a>
+      {' · '}
+      Resume schema:{' '}
+      <a href="https://jsonresume.org/" target="_blank" rel="noopener noreferrer">
+        JSON Resume
+      </a>
+    </FooterWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a "Credits" section to `README.md` listing the resume stack (JSON Resume, developer-mono theme, onepage theme, resumed), framework deps, and the Claude Code agentic engine
- Adds a small muted `Footer` component on public resume pages: "Built with AgentFolio · Resume schema: JSON Resume"
- Self-brands with a link back to `verkyyi/agentfolio`

Closes #61

## Test plan
- [x] `npx tsc -b` clean
- [x] `npm test` — 34/34 pass
- [x] `npm run build` succeeds
- [ ] Visit deployed public slug — footer visible, links open in new tab, hidden in print/PDF
- [ ] Visit `/dashboard` — footer does not appear there

🤖 Generated with [Claude Code](https://claude.com/claude-code)