### PR TITLE
fix(deploy): derive VITE_BASE_PATH from actions/configure-pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,16 +33,17 @@ jobs:
         working-directory: web
         run: npm test
 
+      - id: pages
+        uses: actions/configure-pages@v5
+
       - name: Build web
         working-directory: web
         env:
           VITE_GITHUB_PAT: ${{ secrets.GH_ISSUES_PAT }}
           VITE_GITHUB_REPO: ${{ github.repository }}
-          VITE_BASE_PATH: ${{ endsWith(github.event.repository.name, '.github.io') && '/' || format('/{0}/', github.event.repository.name) }}
+          VITE_BASE_PATH: ${{ steps.pages.outputs.base_path }}
           VITE_CHAT_PROXY_URL: ${{ vars.VITE_CHAT_PROXY_URL }}
         run: npm run build
-
-      - uses: actions/configure-pages@v5
 
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Set these in `web/.env.local` for development, or as GitHub Actions secrets/env 
 | Variable | Purpose |
 |----------|---------|
 | `VITE_GITHUB_REPO` | `your-username/your-repo`. Auto-set in deploy workflow via `${{ github.repository }}`. |
-| `VITE_BASE_PATH` | URL base path. Auto-detected: `/` for user pages, `/<repo-name>/` for project pages. |
+| `VITE_BASE_PATH` | URL base path. Auto-detected from `actions/configure-pages`: `/` for user pages or custom domains, `/<repo-name>/` for project pages. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token for Claude Code in the adapt workflow. Uses your Claude Pro/Team subscription instead of usage-based API billing. |
 | `VITE_CHAT_PROXY_URL` | URL of the deployed chat Worker. If unset, the chat widget doesn't mount. |
 


### PR DESCRIPTION
## Summary
- Previous logic hardcoded base path from repo name, ignoring custom domains
- When a project repo sets a custom subdomain (e.g. `agentfolio.lianghuiyi.com`), Pages serves at the root, not `/agentfolio/` — SPA routing breaks
- Use `actions/configure-pages@v5`'s `base_path` output instead (it already handles user pages, project pages, and custom domains correctly)
- Move `configure-pages` before `Build web` so its output is available to the build env

## Test plan
- [ ] Verify deploy succeeds on verkyyi/agentfolio with new custom domain `agentfolio.lianghuiyi.com` — site loads at subdomain root, slug routing works
- [ ] Verify derived deploys (without custom domain) still get `/<repo-name>/` base path

🤖 Generated with [Claude Code](https://claude.com/claude-code)