### PR TITLE
ci: use WORKFLOW_PAT for cross-workflow dispatches

### DIFF
--- a/.github/workflows/extract.yml
+++ b/.github/workflows/extract.yml
@@ -73,6 +73,6 @@ jobs:
       - name: Trigger structurize workflow
         if: steps.author.outputs.is_bot == 'false'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           gh workflow run structurize.yml

--- a/.github/workflows/fit.yml
+++ b/.github/workflows/fit.yml
@@ -88,5 +88,5 @@ jobs:
       - name: Trigger deploy
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: gh workflow run deploy.yml

--- a/.github/workflows/pdf.yml
+++ b/.github/workflows/pdf.yml
@@ -82,5 +82,5 @@ jobs:
       - name: Trigger deploy
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: gh workflow run deploy.yml

--- a/.github/workflows/structurize.yml
+++ b/.github/workflows/structurize.yml
@@ -101,5 +101,5 @@ jobs:
       - name: Trigger deploy
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: gh workflow run deploy.yml

--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ AgentFolio renders a resume adapted to the target company and role. A three-stag
 2. **Enable GitHub Pages:** go to Settings → Pages → Source → select **GitHub Actions**
 3. **Replace** `data/input/resume.md` with your resume (any format — paste from LinkedIn, PDF text, or write markdown)
 4. **Add target positions** in `data/input/jd/` — one `.md` file per role, filename becomes the URL slug (e.g., `data/input/jd/google.md` → `yoursite.com/google`)
-5. **Set secret** `CLAUDE_CODE_OAUTH_TOKEN` on your fork — uses your Claude Pro/Team subscription instead of usage-based API billing
+5. **Set secrets** on your fork:
+   - `CLAUDE_CODE_OAUTH_TOKEN` — uses your Claude Pro/Team subscription instead of usage-based API billing
+   - `WORKFLOW_PAT` — a fine-grained or classic PAT with `actions: write` (or classic `workflow`) scope, so bot workflows can chain (fit → structurize → pdf → deploy). Without it, each stage's "Trigger …" step 403s and the chain stops after `fit`.
 6. **Push** — GitHub Actions generates adapted resumes, PDFs, and deploys to GitHub Pages
 
 No local runtime needed. No JSON to write. Just markdown and push.
@@ -52,6 +54,7 @@ Set these in `web/.env.local` for development, or as GitHub Actions secrets/env 
 | `VITE_GITHUB_REPO` | `your-username/your-repo`. Auto-set in deploy workflow via `${{ github.repository }}`. |
 | `VITE_BASE_PATH` | URL base path. Auto-detected from `actions/configure-pages`: `/` for user pages or custom domains, `/<repo-name>/` for project pages. |
 | `CLAUDE_CODE_OAUTH_TOKEN` | OAuth token for Claude Code in the adapt workflow. Uses your Claude Pro/Team subscription instead of usage-based API billing. |
+| `WORKFLOW_PAT` | PAT with `actions: write` (fine-grained) or `workflow` (classic) scope. Used by bot workflows to dispatch downstream stages (fit → structurize, extract → structurize, structurize → deploy, pdf → deploy). The default `GITHUB_TOKEN` lacks this permission and 403s on cross-workflow dispatch. |
 | `VITE_CHAT_PROXY_URL` | URL of the deployed chat Worker. If unset, the chat widget doesn't mount. |
 
 ## Enable chat (optional)


### PR DESCRIPTION
## Summary
Fix a latent CI bug: bot workflows (`fit`, `extract`, `pdf`, `structurize`) try to dispatch downstream workflows using the default `GITHUB_TOKEN`, which **fails with HTTP 403**. Consequence: the `fit → structurize → pdf → deploy` chain silently stops after `fit`, and any fork that adds or rotates JDs ends up with fitted markdown but no adapted JSON/PDF — 404s on the live site.

## Root cause
`GITHUB_TOKEN`'s default permissions do not include `actions: write`. GitHub also has recursion-blocking rules that make workflow dispatch from `GITHUB_TOKEN` unreliable even when the permission is granted. PATs (Personal Access Tokens) act as the user, carry explicit scopes, and trigger downstream runs normally.

## Fix
Switch the 4 cross-workflow dispatch steps from `secrets.GITHUB_TOKEN` to a new `secrets.WORKFLOW_PAT`:

- `fit.yml` — "Trigger deploy"
- `extract.yml` — "Trigger structurize workflow"
- `pdf.yml` — "Trigger deploy"
- `structurize.yml` — "Trigger deploy"

## Docs
Document the new secret in `README.md`:

- **Quick Start** step 5: lists `WORKFLOW_PAT` alongside `CLAUDE_CODE_OAUTH_TOKEN`, explains the scope needed (`actions: write` fine-grained, or classic `workflow`)
- **Environment Variables** table: new row explaining why `GITHUB_TOKEN` alone is insufficient and what the PAT scope must be

## Why this was invisible
Forks that never change JDs after initial setup don't re-run the bot chain, so the 403 doesn't surface. The bug becomes visible the moment someone adds or rotates a JD — which is the expected daily use of the product.

## Test plan
- [ ] Create a PAT with `actions: write` (fine-grained) or classic `workflow` scope
- [ ] Add it as `WORKFLOW_PAT` repo secret on a fork
- [ ] Add a new JD in `data/input/jd/`, push
- [ ] Verify `fit` commits fitted markdown, dispatches `deploy.yml` without 403
- [ ] Verify `structurize` runs on the bot commit and dispatches `deploy.yml`
- [ ] Verify `pdf` runs and dispatches `deploy.yml`
- [ ] Confirm the new slug is reachable live

🤖 Generated with [Claude Code](https://claude.com/claude-code)