### PR TITLE
fix(activity): use WORKFLOW_PAT for deploy dispatch

### DIFF
--- a/.github/workflows/activity.yml
+++ b/.github/workflows/activity.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Trigger deploy
         if: steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: gh workflow run deploy.yml


### PR DESCRIPTION
## Summary
Follow-up to PR #70. The new \`activity.yml\` cron dispatches \`deploy.yml\` after committing fresh \`data/github/activity.json\`, but uses \`GITHUB_TOKEN\` which doesn't have \`actions: write\` — the dispatch 403s. Same fix as PR #69 (which swapped the other four bot workflows to \`WORKFLOW_PAT\`): I missed \`activity.yml\` because I wrote it from a spec drafted before #69 landed.

Confirmed against the first live run of \`activity.yml\` (run 24550532485): fetch ✅, commit ✅, \`Trigger deploy\` ❌ exit 1.

## Test plan
- [ ] Merge
- [ ] \`gh workflow run activity.yml\` — verify \`Trigger deploy\` step succeeds (no more 403)
- [ ] Verify a deploy run is dispatched automatically when new activity data is committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)