### PR TITLE
fix(activity): mkdir -p data/github before writing activity.json

### DIFF
--- a/scripts/fetch-github-activity.mjs
+++ b/scripts/fetch-github-activity.mjs
@@ -2,7 +2,7 @@
 // Node 20 script. No deps. Called from .github/workflows/activity.yml.
 // Exports buildActivity for unit tests; runs the fetch when invoked directly.
 
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 
@@ -117,6 +117,7 @@ async function main() {
 
   const activity = buildActivity(login, json.data);
   const outPath = path.resolve('data/github/activity.json');
+  await mkdir(path.dirname(outPath), { recursive: true });
   await writeFile(outPath, JSON.stringify(activity, null, 2) + '\n', 'utf-8');
   console.log(`Wrote ${outPath}`);
 }


### PR DESCRIPTION
## Summary
Make the GitHub activity fetch script self-healing on fresh checkouts. Currently the workflow 403s fail with \`ENOENT\` because \`fetch-github-activity.mjs\` writes \`data/github/activity.json\` without first ensuring the parent directory exists.

## Repro
1. Fork \`agentfolio\` as a derived deploy and overlay framework files without copying \`data/\`.
2. Trigger \`Refresh GitHub Activity\` workflow.
3. See: \`Error: ENOENT: no such file or directory, open '…/data/github/activity.json'\`.

This matches what happened in \`verkyyi/verkyyi.github.io\` after the framework overlay — the \`data/github/.gitkeep\` placeholder didn't carry over, so the workflow broke on first run.

## Fix
One-line change: add \`await mkdir(path.dirname(outPath), { recursive: true });\` before the \`writeFile\` call, and import \`mkdir\` alongside \`writeFile\`.

\`\`\`diff
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
…
   const outPath = path.resolve('data/github/activity.json');
+  await mkdir(path.dirname(outPath), { recursive: true });
   await writeFile(outPath, …);
\`\`\`

\`{ recursive: true }\` is a no-op when the directory already exists, so this doesn't change behavior for existing deploys.

## Side benefit
The \`data/github/.gitkeep\` placeholder becomes optional going forward. Not removing it in this PR (keeps the change minimal and avoids churn), but future forks no longer depend on it.

## Test plan
- [ ] Unit tests (\`npm test\`) still pass — they exercise \`buildActivity\`, not \`main()\`, so this is unchanged
- [ ] Delete \`data/github/\` locally, run \`node scripts/fetch-github-activity.mjs\` with a valid \`GITHUB_TOKEN\` + \`GITHUB_REPOSITORY_OWNER\`, confirm it creates the directory and writes the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)