### PR TITLE
chore: drop orphaned VITE_GITHUB_PAT / VITE_GITHUB_REPO env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,6 @@ jobs:
       - name: Build web
         working-directory: web
         env:
-          VITE_GITHUB_PAT: ${{ secrets.GH_ISSUES_PAT }}
-          VITE_GITHUB_REPO: ${{ github.repository }}
           VITE_BASE_PATH: ${{ steps.pages.outputs.base_path }}
           VITE_CHAT_PROXY_URL: ${{ vars.VITE_CHAT_PROXY_URL }}
         run: npm run build

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,6 +1,8 @@
-# Fine-grained PAT with issues:read+write on your fork only.
-# For local dev, copy this file to .env.local and fill in the values.
-# For production, these are set as Actions secrets / workflow env vars.
-VITE_GITHUB_PAT=
-VITE_GITHUB_REPO=your-username/your-repo
+# Base path for the deployed site.
+# Default `/` for user/org GitHub Pages (e.g. https://you.github.io).
+# Set to `/repo-name/` for project Pages (e.g. https://you.github.io/repo-name/).
 VITE_BASE_PATH=/
+
+# Optional. URL of a server-side proxy that forwards chat messages to the Claude API.
+# If unset, the chat widget is hidden. See docs for deploying a proxy.
+VITE_CHAT_PROXY_URL=


### PR DESCRIPTION
## Summary
- Commit ec22175 (Apr 16, "remove all orphaned code from previous architecture") deleted the chat widget, \`githubApi\`, and analytics tracker — all the web-side code that read \`VITE_GITHUB_PAT\` / \`VITE_GITHUB_REPO\`. \`deploy.yml\` has been baking them into the bundle anyway and \`.env.example\` kept documenting them. Drop both.
- \`.env.example\` now documents only the two env vars the bundle actually reads (\`VITE_BASE_PATH\`, \`VITE_CHAT_PROXY_URL\`).

## Follow-up for the maintainer
After this lands, the \`GH_ISSUES_PAT\` repo secret is unused. Delete with:

\`\`\`
gh secret delete GH_ISSUES_PAT --repo verkyyi/agentfolio
\`\`\`

Then create \`WORKFLOW_PAT\` (the sole remaining PAT — fine-grained, \`actions:write\` on this repo only) so the five bot workflows' \`gh workflow run deploy.yml\` step succeeds.

## Test plan
- [x] \`cd web && npm run build\` succeeds locally without the vars.
- [ ] CI deploy.yml succeeds on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)