### PR TITLE
Add proxy auto-deploy workflow

### DIFF
--- a/.github/workflows/proxy.yml
+++ b/.github/workflows/proxy.yml
@@ -1,0 +1,35 @@
+name: Deploy chat proxy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'proxy/**'
+      - 'data/github/activity.json'
+      - '.github/workflows/proxy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: proxy-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: proxy
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: proxy/package-lock.json
+      - run: npm ci
+      - run: npx vitest run
+      - run: npx tsc --noEmit
+      - name: Deploy with Wrangler
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy


### PR DESCRIPTION
## Summary

Adds `.github/workflows/proxy.yml` to auto-deploy the Cloudflare Worker on pushes to main that touch `proxy/**` (or the bundled `data/github/activity.json`). Also supports manual runs via `workflow_dispatch`.

Fixes the gap surfaced by PR #100: Pages auto-deploys the frontend on every merge, but the worker was left to manual deploys, causing a protocol mismatch (new frontend ↔ old worker) until I deployed it by hand.

## What it does

- Triggers on `proxy/**` changes (and the bundled activity JSON) pushed to main.
- Runs `npm ci`, `vitest`, and `tsc --noEmit` before deploying.
- Deploys via `wrangler deploy` using `CLOUDFLARE_API_TOKEN` (added as a repo secret).
- `concurrency: proxy-deploy` prevents overlapping deploys without cancelling in-flight work.

## Test plan

- [ ] Merge; confirm the workflow runs on any future `proxy/**` change.
- [ ] Trigger `workflow_dispatch` from the Actions UI to smoke-test.
- [ ] Edit `proxy/src/prompt.ts` in a throwaway PR and verify the deploy lands before closing/merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)