### PR TITLE
[codex] Fix mobile chat input and profile links

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,54 @@
+name: PR Preview
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - 'data/**'
+      - '.github/workflows/pr-preview.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-preview:
+    runs-on: ubuntu-latest
+    env:
+      PREVIEW_ID: ${{ github.event.pull_request.number || github.run_number }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Install web deps
+        working-directory: web
+        run: npm ci
+
+      - name: Run web tests
+        working-directory: web
+        run: npm test
+
+      - name: Build portable preview
+        working-directory: web
+        env:
+          VITE_BASE_PATH: ./
+          VITE_CHAT_PROXY_URL: ${{ vars.VITE_CHAT_PROXY_URL }}
+        run: npm run build
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentfolio-preview-${{ env.PREVIEW_ID }}
+          path: web/dist
+          if-no-files-found: error
+          retention-days: 7

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,7 +67,12 @@ function ResumePage() {
     <>
       <div className="resume-viewport">
         <main className="resume-main">
-          <Hero name={basics.name ?? ''} tagline={tagline} image={basics.image} />
+          <Hero
+            name={basics.name ?? ''}
+            tagline={tagline}
+            image={basics.image}
+            profiles={basics.profiles}
+          />
           <ChatPanel
             key={activeSlug}
             slug={activeSlug}

--- a/web/src/__tests__/App.test.tsx
+++ b/web/src/__tests__/App.test.tsx
@@ -4,7 +4,11 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import App from '../App';
 
 const mockAdapted = {
-  basics: { name: 'Verky Yi', summary: 'Product engineer.' },
+  basics: {
+    name: 'Verky Yi',
+    summary: 'Product engineer.',
+    profiles: [{ network: 'GitHub', url: 'https://github.com/verky' }],
+  },
   work: [],
   meta: { agentfolio: { suggestions: ['Roles?', 'Recent work?', 'AI experience?', 'Resume?'] } },
 };
@@ -29,7 +33,8 @@ describe('App landing', () => {
   it('renders Hero and ChatPanel, not ResumeTheme or GithubActivity', async () => {
     render(<App />);
     await waitFor(() => expect(screen.getByText('Verky Yi')).toBeInTheDocument());
-    expect(screen.getByText(/This page is an agent/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute('href', 'https://github.com/verky');
+    expect(screen.queryByText(/This page is an agent/i)).not.toBeInTheDocument();
     expect(screen.getByLabelText('Chat')).toBeInTheDocument();
     expect(screen.queryByTestId('resume-theme')).not.toBeInTheDocument();
     expect(screen.queryByTestId('github-activity')).not.toBeInTheDocument();

--- a/web/src/__tests__/Hero.test.tsx
+++ b/web/src/__tests__/Hero.test.tsx
@@ -3,17 +3,23 @@ import { describe, expect, it } from 'vitest';
 import { Hero } from '../components/Hero';
 
 describe('Hero', () => {
-  it('renders name, tagline, and explainer', () => {
+  it('renders name, tagline, and profile links', () => {
     render(
       <Hero
         name="Verky Yi"
         tagline="Product engineer building AI-native tools"
         image="/avatar.png"
+        profiles={[
+          { network: 'LinkedIn', url: 'https://linkedin.com/in/verky' },
+          { network: 'GitHub', url: 'https://github.com/verky' },
+        ]}
       />
     );
     expect(screen.getByText('Verky Yi')).toBeInTheDocument();
     expect(screen.getByText(/Product engineer building AI-native tools/)).toBeInTheDocument();
-    expect(screen.getByText(/This page is an agent/i)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute('href', 'https://linkedin.com/in/verky');
+    expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute('href', 'https://github.com/verky');
+    expect(screen.queryByText(/This page is an agent/i)).not.toBeInTheDocument();
   });
 
   it('falls back to initials when no image', () => {
@@ -24,6 +30,6 @@ describe('Hero', () => {
   it('renders without tagline', () => {
     render(<Hero name="Verky Yi" />);
     expect(screen.getByText('Verky Yi')).toBeInTheDocument();
-    expect(screen.getByText(/This page is an agent/i)).toBeInTheDocument();
+    expect(screen.queryByText(/This page is an agent/i)).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/ChatPanel.css
+++ b/web/src/components/ChatPanel.css
@@ -108,22 +108,42 @@
   margin-top: auto;
   padding-top: 14px;
   border-top: 1px solid var(--border-soft);
+  min-width: 0;
 }
 .chatp-input-row input {
   flex: 1;
-  background: transparent;
-  border: none;
+  min-width: 0;
+  width: 100%;
+  min-height: 32px;
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
   color: var(--text);
   font: inherit;
   font-size: 13px;
+  line-height: 1.4;
   outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+}
+.chatp-input-row input:focus {
+  border-color: var(--accent-green);
 }
 /* iOS Safari auto-zooms focused inputs < 16px; bump on touch devices to hold the viewport lock. */
 @media (pointer: coarse) {
-  .chatp-input-row input { font-size: 16px; }
+  .chatp-input-row {
+    gap: 8px;
+    padding-top: 12px;
+  }
+  .chatp-input-row input {
+    font-size: 16px;
+    min-height: 40px;
+  }
 }
 .chatp-input-row input:disabled { opacity: 0.6; }
 .chatp-input-row button[type="submit"] {
+  flex: 0 0 auto;
   font-family: inherit;
   font-size: 11px;
   padding: 4px 10px;

--- a/web/src/components/Hero.css
+++ b/web/src/components/Hero.css
@@ -24,4 +24,11 @@
 .hero-avatar img { width: 100%; height: 100%; object-fit: cover; }
 .hero-name { margin: 0; font-size: 22px; font-weight: 600; }
 .hero-tagline { margin: 4px 0 0; font-size: 14px; opacity: 0.72; }
-.hero-explainer { margin: 12px 0 0; font-size: 13px; opacity: 0.6; max-width: 420px; }
+.hero-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px 16px;
+  margin-top: 12px;
+  font-size: 13px;
+}

--- a/web/src/components/Hero.tsx
+++ b/web/src/components/Hero.tsx
@@ -4,6 +4,7 @@ export interface HeroProps {
   name: string;
   tagline?: string;
   image?: string;
+  profiles?: { network: string; url: string }[];
 }
 
 function initials(name: string): string {
@@ -15,7 +16,9 @@ function initials(name: string): string {
     .slice(0, 2);
 }
 
-export function Hero({ name, tagline, image }: HeroProps) {
+export function Hero({ name, tagline, image, profiles }: HeroProps) {
+  const visibleProfiles = profiles?.filter((p) => p.network && p.url) ?? [];
+
   return (
     <header className="hero">
       <div className="hero-avatar" data-testid="hero-avatar">
@@ -23,9 +26,15 @@ export function Hero({ name, tagline, image }: HeroProps) {
       </div>
       <h1 className="hero-name">{name}</h1>
       {tagline && <p className="hero-tagline">{tagline}</p>}
-      <p className="hero-explainer">
-        This page is an agent — ask it anything about my background, projects, or fit for a role.
-      </p>
+      {visibleProfiles.length > 0 && (
+        <nav className="hero-links" aria-label="Social links">
+          {visibleProfiles.map((profile) => (
+            <a key={`${profile.network}-${profile.url}`} href={profile.url} target="_blank" rel="noreferrer">
+              {profile.network}
+            </a>
+          ))}
+        </nav>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the hero agent explainer with simple profile links sourced from resume profiles.
- Make the chat input render as a visible bounded field on narrow mobile viewports.
- Add a PR preview artifact workflow that builds `web/dist` for future pull requests.
- Update app and hero tests for the revised hero behavior.

## Why
On mobile Safari-style layouts, the chat input could appear poorly because it was a transparent borderless input inside a compact flex row. The hero also still described the page as an agent, while this view should present plain social links such as LinkedIn and GitHub.

The repo only had a production GitHub Pages deployment for `main`; the new PR Preview workflow creates a lightweight staging artifact without adding hosting infrastructure or touching production deploys.

## Validation
- `npm test`
- `npm run build`
- `VITE_BASE_PATH=./ npm run build`
- `npx playwright test e2e/portfolio-layout.spec.ts`
- Parsed `.github/workflows/pr-preview.yml` with PyYAML.
- Manual Playwright mobile check at 390x844: no horizontal overflow; input rendered 40px high with 16px text.

## Note
GitHub only exposes/runs a newly added workflow after the workflow file exists on the default branch, so the PR Preview workflow will start producing artifacts for subsequent PRs after this lands.
