### PR TITLE
[codex] Remove hero avatar

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -70,7 +70,6 @@ function ResumePage() {
           <Hero
             name={basics.name ?? ''}
             tagline={tagline}
-            image={basics.image}
             profiles={basics.profiles}
           />
           <ChatPanel

--- a/web/src/__tests__/Hero.test.tsx
+++ b/web/src/__tests__/Hero.test.tsx
@@ -8,7 +8,6 @@ describe('Hero', () => {
       <Hero
         name="Verky Yi"
         tagline="Product engineer building AI-native tools"
-        image="/avatar.png"
         profiles={[
           { network: 'LinkedIn', url: 'https://linkedin.com/in/verky' },
           { network: 'GitHub', url: 'https://github.com/verky' },
@@ -20,11 +19,12 @@ describe('Hero', () => {
     expect(screen.getByRole('link', { name: 'LinkedIn' })).toHaveAttribute('href', 'https://linkedin.com/in/verky');
     expect(screen.getByRole('link', { name: 'GitHub' })).toHaveAttribute('href', 'https://github.com/verky');
     expect(screen.queryByText(/This page is an agent/i)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-avatar')).not.toBeInTheDocument();
   });
 
-  it('falls back to initials when no image', () => {
+  it('does not render the old initials avatar', () => {
     render(<Hero name="Verky Yi" />);
-    expect(screen.getByTestId('hero-avatar')).toHaveTextContent('VY');
+    expect(screen.queryByTestId('hero-avatar')).not.toBeInTheDocument();
   });
 
   it('renders without tagline', () => {

--- a/web/src/components/Hero.css
+++ b/web/src/components/Hero.css
@@ -3,25 +3,10 @@
   flex-direction: column;
   align-items: center;
   text-align: center;
-  padding: 40px 16px 24px;
+  padding: 24px 16px 18px;
   max-width: 640px;
   margin: 0 auto;
 }
-.hero-avatar {
-  width: 64px;
-  height: 64px;
-  border-radius: 50%;
-  background: var(--accent-dim, #e8e8e8);
-  color: var(--fg, #333);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-weight: 600;
-  font-size: 20px;
-  overflow: hidden;
-  margin-bottom: 12px;
-}
-.hero-avatar img { width: 100%; height: 100%; object-fit: cover; }
 .hero-name { margin: 0; font-size: 22px; font-weight: 600; }
 .hero-tagline { margin: 4px 0 0; font-size: 14px; opacity: 0.72; }
 .hero-links {

--- a/web/src/components/Hero.tsx
+++ b/web/src/components/Hero.tsx
@@ -3,27 +3,14 @@ import './Hero.css';
 export interface HeroProps {
   name: string;
   tagline?: string;
-  image?: string;
   profiles?: { network: string; url: string }[];
 }
 
-function initials(name: string): string {
-  return name
-    .split(/\s+/)
-    .filter(Boolean)
-    .map((p) => p[0]?.toUpperCase() ?? '')
-    .join('')
-    .slice(0, 2);
-}
-
-export function Hero({ name, tagline, image, profiles }: HeroProps) {
+export function Hero({ name, tagline, profiles }: HeroProps) {
   const visibleProfiles = profiles?.filter((p) => p.network && p.url) ?? [];
 
   return (
     <header className="hero">
-      <div className="hero-avatar" data-testid="hero-avatar">
-        {image ? <img src={image} alt={name} /> : <span>{initials(name)}</span>}
-      </div>
       <h1 className="hero-name">{name}</h1>
       {tagline && <p className="hero-tagline">{tagline}</p>}
       {visibleProfiles.length > 0 && (


### PR DESCRIPTION
## Summary
- Remove the round hero avatar/initials block from the homepage hero.
- Tighten hero vertical padding so more of the chatbot is visible above the fold.
- Update hero tests to assert the old avatar no longer renders.

## Why
The avatar consumed vertical space without adding useful interaction. Removing it makes the chat-first layout more compact, especially on mobile.

## Validation
- `npm test -- src/__tests__/Hero.test.tsx src/__tests__/App.test.tsx`
- `npm run build`
- `npx playwright test e2e/portfolio-layout.spec.ts`
