### PR TITLE
[codex] Optimize mobile chat layout

### DIFF
--- a/web/e2e/portfolio-layout.spec.ts
+++ b/web/e2e/portfolio-layout.spec.ts
@@ -31,6 +31,8 @@ test.describe('Portfolio layout — chat-first', () => {
     await page.setViewportSize({ width: 375, height: 667 });
     await page.goto('./');
     await expect(page.locator('.hero')).toBeVisible();
+    await expect(page.locator('.chatp-suggestion:visible')).toHaveCount(1);
+    await expect(page.getByRole('textbox', { name: /message/i })).toBeVisible();
     const overflow = await page.evaluate(() => document.documentElement.scrollWidth > document.documentElement.clientWidth);
     expect(overflow).toBe(false);
   });

--- a/web/src/components/ChatPanel.css
+++ b/web/src/components/ChatPanel.css
@@ -16,7 +16,10 @@
 
 @media (max-width: 640px) {
   .chatp {
-    margin: 14px var(--side-gutter-mobile) 0;
+    margin: 8px 12px 0;
+    padding: 14px 12px 12px;
+    border-radius: 8px;
+    gap: 9px;
   }
 }
 
@@ -47,6 +50,14 @@
   flex-direction: column;
   gap: 12px;
   min-height: 300px;
+}
+
+@media (max-width: 640px) {
+  .chatp-messages {
+    gap: 9px;
+    min-height: 0;
+    -webkit-overflow-scrolling: touch;
+  }
 }
 
 .chatp-msg {
@@ -101,6 +112,23 @@
 }
 .chatp-suggestion:hover { color: var(--accent-green); border-color: var(--accent-green); }
 
+@media (max-width: 640px) {
+  .chatp-suggestions {
+    display: block;
+    margin: 4px 0 6px;
+  }
+
+  .chatp-suggestion {
+    width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .chatp-suggestion:nth-child(n+2) {
+    display: none;
+  }
+}
+
 .chatp-input-row {
   display: flex;
   align-items: center;
@@ -134,11 +162,11 @@
 @media (pointer: coarse) {
   .chatp-input-row {
     gap: 8px;
-    padding-top: 12px;
+    padding-top: 10px;
   }
   .chatp-input-row input {
     font-size: 16px;
-    min-height: 40px;
+    min-height: 38px;
   }
 }
 .chatp-input-row input:disabled { opacity: 0.6; }

--- a/web/src/components/Footer.tsx
+++ b/web/src/components/Footer.tsx
@@ -25,6 +25,10 @@ const FooterWrapper = styled.footer`
   @media print {
     display: none;
   }
+
+  @media (max-width: 640px) {
+    display: none;
+  }
 `;
 
 export function Footer() {

--- a/web/src/components/Hero.css
+++ b/web/src/components/Hero.css
@@ -17,3 +17,30 @@
   margin-top: 12px;
   font-size: 13px;
 }
+
+@media (max-width: 640px) {
+  .hero {
+    padding: 14px 12px 8px;
+  }
+
+  .hero-name {
+    font-size: 20px;
+    line-height: 1.2;
+  }
+
+  .hero-tagline {
+    display: -webkit-box;
+    margin-top: 3px;
+    font-size: 12px;
+    line-height: 1.35;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+  }
+
+  .hero-links {
+    gap: 6px 12px;
+    margin-top: 7px;
+    font-size: 12px;
+  }
+}


### PR DESCRIPTION
## Summary
- Tighten mobile hero and chat panel spacing so the chatbot gets more viewport height.
- Show only one suggestion chip on mobile and keep the input visible.
- Remove the footer from mobile viewport layouts.
- Add E2E coverage for mobile one-hint/no-overflow behavior.

## Why
Mobile Safari on iPhone was still cramped after removing the avatar. The chat panel had a fixed message minimum height, multiple visible suggestion chips, and footer/hero chrome competing with the input area.

## Validation
- `npm test -- src/__tests__/ChatPanel.test.tsx src/__tests__/Hero.test.tsx src/__tests__/App.test.tsx`
- `npm run build`
- `npx playwright test e2e/portfolio-layout.spec.ts`
- Manual mobile metrics at 390x844: one visible suggestion, no horizontal overflow, footer hidden, input visible at bottom.
